### PR TITLE
Add codeship badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Codeship Status for glebec/send-seekable](https://codeship.com/projects/641e1c10-0600-0134-54e5-56f9205ea8b9/status?branch=master)](https://codeship.com/projects/154589)
+
 # Send-Seekable
 
 ### Express.js/connect middleware for serving partial content (206) byte-range responses from buffers or streams


### PR DESCRIPTION
Mostly for the sake of checking out Codeship, but also for easy checks on PRs.
